### PR TITLE
Updated .nuspec to include docoptnet.dll

### DIFF
--- a/TypeScripter.nuspec
+++ b/TypeScripter.nuspec
@@ -14,6 +14,7 @@
   </metadata>
 	<files>
 		<file src="bin/Release/TypeScripter.exe" target="tools"/>
+		<file src="bin/Release/DocoptNet.dll" target="tools"/>
 		<file src="TypeScripter.Attributes/bin/Release/TypeScripter.Attributes.dll" target="lib"/>
 	</files>
 </package>


### PR DESCRIPTION
This is to fix the Nuget package and include the needed dlls into the resulting Nuget package.