### PR TITLE
CombineImports option

### DIFF
--- a/CommandLineArguments.cs
+++ b/CommandLineArguments.cs
@@ -15,5 +15,6 @@ namespace TypeScripter
 		public const string Path = "<APIPATH>";
 		public const string ClassNames = "--class";
 		public const string NewHttp = "--httpclient";
+		public const string CombineImports = "--combineimports";
 	}
 }

--- a/Generators/DataServiceGenerator.cs
+++ b/Generators/DataServiceGenerator.cs
@@ -35,18 +35,21 @@ namespace TypeScripter.Generators
 			sb.AppendLine("import { Observable } from 'rxjs';");
 			sb.AppendLine("import * as moment from 'moment';");
 
+			var startingImport = "import {";
+			var endingImport = "} from '.';";
+
 			if (CombineImports) {
-				sb.AppendLine("import {");
-				foreach (var import in models.OrderBy(m => m.Name)) {
-					sb.AppendLine(string.Format("\t{0},", import.Name));
+				sb.AppendLine(string.Format("{0}", startingImport));
+				foreach (var m in models.OrderBy(m => m.Name)) {
+					sb.AppendLine(string.Format("\t{0},", m.Name));
 				}
-				sb.AppendLine("} from './';\n");
+				sb.AppendLine(string.Format("{0}", endingImport));
 			} else {
 				foreach (var m in models.OrderBy(m => m.Name)) {
-					sb.AppendLine("import { " + m.Name + " } from '.';");
+					sb.AppendLine(string.Format("{0} {1} {2}", startingImport, m.Name, endingImport));
 				}
-				sb.AppendLine("");
 			}
+			sb.AppendLine("");
 
 			sb.AppendLine("@Injectable()");
 			sb.AppendLine("export class DataService {");

--- a/Generators/DataServiceGenerator.cs
+++ b/Generators/DataServiceGenerator.cs
@@ -12,7 +12,7 @@ namespace TypeScripter.Generators
 		public static string HttpClient = "HttpClientModule";
 		public static string Http = "HttpModule";
 
-		public static List<string> Generate(string apiRelativePath, List<Type> apiControllers, HashSet<Type> models, string targetPath, string HttpModule)
+		public static List<string> Generate(string apiRelativePath, List<Type> apiControllers, HashSet<Type> models, string targetPath, string HttpModule, bool CombineImports = false)
 		{
 			if (string.IsNullOrWhiteSpace(apiRelativePath))
 			{
@@ -34,12 +34,20 @@ namespace TypeScripter.Generators
 			sb.AppendLine(HttpModule == HttpClient ? "import { HttpClient, HttpErrorResponse } from '@angular/common/http';" : "import { Http, Response } from '@angular/http';");
 			sb.AppendLine("import { Observable } from 'rxjs';");
 			sb.AppendLine("import * as moment from 'moment';");
-			foreach (var m in models.OrderBy(m => m.Name))
-			{
-				sb.AppendLine("import { " + m.Name + " } from '.';");
+
+			if (CombineImports) {
+				sb.AppendLine("import {");
+				foreach (var import in models.OrderBy(m => m.Name)) {
+					sb.AppendLine(string.Format("\t{0},", import.Name));
+				}
+				sb.AppendLine("} from './';\n");
+			} else {
+				foreach (var m in models.OrderBy(m => m.Name)) {
+					sb.AppendLine("import { " + m.Name + " } from '.';");
+				}
+				sb.AppendLine("");
 			}
 
-			sb.AppendLine("");
 			sb.AppendLine("@Injectable()");
 			sb.AppendLine("export class DataService {");
 

--- a/Options.cs
+++ b/Options.cs
@@ -11,5 +11,6 @@ namespace TypeScripter
 		[DataMember] public string[] ControllerBaseClassNames { get; set; }
 		[DataMember] public string ApiRelativePath { get; set; }
         [DataMember] public string HttpModule { get; set; }
+		[DataMember] public bool CombineImports { get; set; }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -28,7 +28,7 @@ namespace TypeScripter
       --files=<FILES>         Comma seperated list of .dll files to generate models from. [ default: *.client.dll ]
       --class=<CLASSNAMES>    Comma seperated list of controller class names. [ default: ApiController ]
       --httpclient            Generated data service will use the new HttpClientModule for angular 4.
-	  --combineimports        Combines model imports to come from the generated index, rather than individual model files. [default: false]
+      --combineimports        Combines model imports to come from the generated index, rather than individual model files. [default: false]
       -h --help               Show this screen.
 
       <SETTINGSFILE>          Path to a json settings file

--- a/Program.cs
+++ b/Program.cs
@@ -20,7 +20,7 @@ namespace TypeScripter
 
     Usage:
       Typescripter.exe <SETTINGSFILE>
-      Typescripter.exe <SOURCE> <DESTINATION> [<APIPATH> [ --httpclient ]]
+      Typescripter.exe <SOURCE> <DESTINATION> [<APIPATH> [ --httpclient ] [ --combineimports ]]
                        [--files=<FILES> | --class=<CLASSNAMES>]...
       Typescripter.exe ( -h | --help )
 
@@ -28,6 +28,7 @@ namespace TypeScripter
       --files=<FILES>         Comma seperated list of .dll files to generate models from. [ default: *.client.dll ]
       --class=<CLASSNAMES>    Comma seperated list of controller class names. [ default: ApiController ]
       --httpclient            Generated data service will use the new HttpClientModule for angular 4.
+	  --combineimports        Combines model imports to come from the generated index, rather than individual model files. [default: false]
       -h --help               Show this screen.
 
       <SETTINGSFILE>          Path to a json settings file
@@ -39,6 +40,7 @@ namespace TypeScripter
                                             ""ControllerBaseClassNames"": [ ""ApiController"" ],
                                             ""ApiRelativePath"": ""api"",
                                             ""HttpModule"": ""HttpClientModule""
+                                            ""CombineImports"": true|false [default: false]
                                         }
       <SOURCE>                The path that contains the .dll(s)
       <DESTINATION>           The destination path where the generated models will be placed
@@ -67,7 +69,7 @@ namespace TypeScripter
 			var targetPath = AbsolutePath(_options.Destination);
 			// Invoke all generators and pass the results to the index generator
 			var allGeneratedNames = IndexGenerator.Generate(targetPath,
-				EntityGenerator.Generate(targetPath, allModels),
+				EntityGenerator.Generate(targetPath, allModels, _options.CombineImports),
 				DataServiceGenerator.Generate(_options.ApiRelativePath, apiControllers, controllerModels, targetPath, _options.HttpModule)
 			);
 			RemoveNonGeneratedFiles(targetPath, allGeneratedNames);
@@ -114,6 +116,9 @@ namespace TypeScripter
 						{
 							throw new Exception(String.Format("HttpModule must be one of {0} or {1}", DataServiceGenerator.Http, DataServiceGenerator.HttpClient));
 						}
+						if (!_options.CombineImports) {
+							_options.CombineImports = false;
+						}
 					}
 					catch (Exception e)
 					{
@@ -135,6 +140,7 @@ namespace TypeScripter
 				ValueObject apipath = arguments[CommandLineArguments.Path];
 				ValueObject classnames = arguments[CommandLineArguments.ClassNames];
 				ValueObject newhttp = arguments[CommandLineArguments.NewHttp];
+				ValueObject combineImports = arguments[CommandLineArguments.CombineImports];
 				_options = new Options
 				{
 					Source = source != null && source.IsString ? (string)source.Value : "./",
@@ -143,6 +149,7 @@ namespace TypeScripter
 					Files = files != null && files.IsList && files.AsList.Count == 1 ? ((string)(((ValueObject)files.AsList[0]).Value)).Split(',') : new[] { "*.client.dll" },
 					ControllerBaseClassNames = classnames != null && classnames.IsList && classnames.AsList.Count == 1 ? ((string)(((ValueObject)classnames.AsList[0]).Value)).Split(',') : new[] { "ApiController" },
 					HttpModule = newhttp != null && newhttp.IsTrue ? DataServiceGenerator.HttpClient : DataServiceGenerator.Http,
+					CombineImports = combineImports != null && combineImports.IsTrue ? true : false
 				};
 			}
 			return 0;

--- a/Program.cs
+++ b/Program.cs
@@ -70,7 +70,7 @@ namespace TypeScripter
 			// Invoke all generators and pass the results to the index generator
 			var allGeneratedNames = IndexGenerator.Generate(targetPath,
 				EntityGenerator.Generate(targetPath, allModels, _options.CombineImports),
-				DataServiceGenerator.Generate(_options.ApiRelativePath, apiControllers, controllerModels, targetPath, _options.HttpModule)
+				DataServiceGenerator.Generate(_options.ApiRelativePath, apiControllers, controllerModels, targetPath, _options.HttpModule, _options.CombineImports)
 			);
 			RemoveNonGeneratedFiles(targetPath, allGeneratedNames);
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Typescripter.
 
     Usage:
       Typescripter.exe <SETTINGSFILE>
-      Typescripter.exe <SOURCE> <DESTINATION> [<APIPATH> [ --httpclient ]]
+      Typescripter.exe <SOURCE> <DESTINATION> [<APIPATH> [ --httpclient ] [ --combineimports ]]
                        [--files=<FILES> | --class=<CLASSNAMES>]...
       Typescripter.exe ( -h | --help )
 
@@ -19,6 +19,7 @@ Typescripter.
       --files=<FILES>         Comma seperated list of .dll files to generate models from. [ default: *.client.dll ]
       --class=<CLASSNAMES>    Comma seperated list of controller class names. [ default: ApiController ]
       --httpclient            Generated data service will use the new HttpClientModule for angular 4.
+      --combineimports        Combines model imports to come from the generated index file, instead of individual models. [default: false]
       -h --help               Show this screen.
 
       <SETTINGSFILE>          Path to a json settings file
@@ -29,7 +30,8 @@ Typescripter.
                                             "Files": [ "*.dll" ],
                                             "ControllerBaseClassNames": [ "ApiController" ],
                                             "ApiRelativePath": "api",
-                                            "HttpModule": "HttpClientModule"
+                                            "HttpModule": "HttpClientModule",
+                                            "CombineImports": true|false [default: false]
                                         }
       <SOURCE>                The path that contains the .dll(s)
       <DESTINATION>           The destination path where the generated models will be placed


### PR DESCRIPTION
When upgrading to Webpack3, I would get weird circular dependency errors. Combining the internal imports to reference the index file fixed this.