### PR TITLE
Handle generic types better, including Task<T>

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using TypeScripter.Generators;
 using DocoptNet;
 
@@ -240,7 +242,12 @@ namespace TypeScripter
 
 		private static IEnumerable<Type> GetModelTypes(Type t)
 		{
-			if (t.GetCustomAttributes().Any(x => x.GetType().Name == "TypeScripterIgnoreAttribute")) yield break;
+			if (t.GetCustomAttributes().Any(x => x.GetType().Name == "TypeScripterIgnoreAttribute")
+				|| t == typeof(Task))
+			{
+				yield break;
+			}
+
 			if (t.IsModelType() || t.IsEnum)
 			{
 				if (t.IsArray)
@@ -254,7 +261,7 @@ namespace TypeScripter
 			}
 			else if (t.IsGenericType)
 			{
-				foreach (var a in t.GetGenericArguments().Where(a => a.IsModelType()).SelectMany(GetModelTypes))
+				foreach (var a in t.GetGenericArguments().Where(a => a.IsModelType() || a.IsGenericType).SelectMany(GetModelTypes))
 				{
 					yield return a;
 				}

--- a/TypeScripter.Tests/Properties/AssemblyInfo.cs
+++ b/TypeScripter.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TypeScripter.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TypeScripter.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b7b236f8-bf1b-4ae7-8956-e0e2dd998dbc")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TypeScripter.Tests/TypeScripter.Tests.csproj
+++ b/TypeScripter.Tests/TypeScripter.Tests.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B7B236F8-BF1B-4AE7-8956-E0E2DD998DBC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TypeScripter.Tests</RootNamespace>
+    <AssemblyName>TypeScripter.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="UtilsUnitTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TypeScripter.csproj">
+      <Project>{F974A8BF-60A5-42BE-BF15-EFD868FDDF85}</Project>
+      <Name>TypeScripter</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/TypeScripter.Tests/UtilsUnitTests.cs
+++ b/TypeScripter.Tests/UtilsUnitTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TypeScripter;
+
+namespace TypeScripter.Tests
+{
+	[TestClass]
+	public class UtilsUnitTests
+	{
+		[TestMethod]
+		public void ToTypeScripterType_ListOfInt()
+		{
+			Assert.AreEqual("number[]", typeof(List<int>).ToTypeScriptType().Name);
+		}
+
+		[TestMethod]
+		public void ToTypeScripterType_ListOfObject()
+		{
+			Assert.AreEqual("UtilsUnitTests[]", typeof(List<UtilsUnitTests>).ToTypeScriptType().Name);
+		}
+
+		[TestMethod]
+		public void ToTypeScripterType_ArrayOfInt()
+		{
+			Assert.AreEqual("number[]", typeof(int[]).ToTypeScriptType().Name);
+		}
+
+		[TestMethod]
+		public void ToTypeScripterType_ArrayOfObject()
+		{
+			Assert.AreEqual("UtilsUnitTests[]", typeof(UtilsUnitTests[]).ToTypeScriptType().Name);
+		}
+
+		[TestMethod]
+		public void ToTypeScripterType_IEnumerableOfInt()
+		{
+			Assert.AreEqual("number[]", typeof(IEnumerable<int>).ToTypeScriptType().Name);
+		}
+	}
+}

--- a/TypeScripter.sln
+++ b/TypeScripter.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TypeScripter", "TypeScripter.csproj", "{F974A8BF-60A5-42BE-BF15-EFD868FDDF85}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TypeScripter.Attributes", "TypeScripter.Attributes\TypeScripter.Attributes.csproj", "{2173B73B-8E8C-4A55-B072-8E9776CF0F73}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TypeScripter.Tests", "TypeScripter.Tests\TypeScripter.Tests.csproj", "{B7B236F8-BF1B-4AE7-8956-E0E2DD998DBC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{2173B73B-8E8C-4A55-B072-8E9776CF0F73}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2173B73B-8E8C-4A55-B072-8E9776CF0F73}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2173B73B-8E8C-4A55-B072-8E9776CF0F73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7B236F8-BF1B-4AE7-8956-E0E2DD998DBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7B236F8-BF1B-4AE7-8956-E0E2DD998DBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7B236F8-BF1B-4AE7-8956-E0E2DD998DBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7B236F8-BF1B-4AE7-8956-E0E2DD998DBC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Utils.cs
+++ b/Utils.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace TypeScripter {
 	public static class Utils {
@@ -22,13 +23,13 @@ namespace TypeScripter {
 		}
 		
 		public static TypeDetails ToTypeScriptType(this Type t) {
-			if(IsModelType(t) || t.IsEnum) {
+			if (IsModelType(t) || t.IsEnum) {
 				return new TypeDetails(t.Name);
 			}
-			if(t == typeof(bool)) {
+			if (t == typeof(bool)) {
 				return new TypeDetails("boolean");
 			}
-			if(t == typeof(byte)
+			if (   t == typeof(byte)
 				|| t == typeof(sbyte)
 				|| t == typeof(ushort)
 				|| t == typeof(short)
@@ -41,20 +42,36 @@ namespace TypeScripter {
 				|| t == typeof(decimal)) {
 				return new TypeDetails("number");
 			}
-			if(t == typeof(string) || t == typeof(char)) {
+			if (t == typeof(string) || t == typeof(char)) {
 				return new TypeDetails("string");
 			}
-			if(t.Name == "List`1" || (t.IsGenericType && typeof(IEnumerable<object>).IsAssignableFrom(t))) {
+			if (t.IsArray) {
+				return new TypeDetails(ToTypeScriptType(t.GetElementType()) + "[]", " = []");
+			}
+			if (t.IsGenericType && IsGenericEnumerable(t)) {
 				return new TypeDetails(ToTypeScriptType(t.GetGenericArguments()[0]) + "[]", " = []");
 			}
-			if(t.Name == "Nullable`1") {
+			if (t.Name == "Nullable`1") {
 				return ToTypeScriptType(t.GetGenericArguments()[0]);
 			}
-			if(t == typeof(DateTime)) {
+			if (t == typeof(DateTime)) {
 				return new TypeDetails("moment.Moment");
+			}
+			if (t.IsGenericType && t.GetGenericArguments().Length == 1)
+			{
+				return ToTypeScriptType(t.GetGenericArguments()[0]);
 			}
 
 			return new TypeDetails("any");
+		}
+
+		private static bool IsGenericEnumerable(Type t)
+		{
+			return t.IsGenericType 
+				&& (
+					t.GetGenericTypeDefinition() == typeof(IEnumerable<>) 
+					|| t.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+				);
 		}
 
 		public static bool IsModelType(this Type t) {


### PR DESCRIPTION
This fixes all the situations I've seen when the return type is a Task<T> and also handles arrays/lists of value types (like int) better as well.