### PR TITLE
Dictionaries should map to the typescript 'any' type until we decide …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,5 @@ rebuild.cmd
 .vs/**
 **/*.suo
 /.vs/TypeScripter/v14/*.suo
+
+*.ncrunchsolution

--- a/TypeScripter.Tests/UtilsUnitTests.cs
+++ b/TypeScripter.Tests/UtilsUnitTests.cs
@@ -38,5 +38,17 @@ namespace TypeScripter.Tests
 		{
 			Assert.AreEqual("number[]", typeof(IEnumerable<int>).ToTypeScriptType().Name);
 		}
+
+		[TestMethod]
+		public void ToTypeScripterType_Dictionary_Int_Object()
+		{
+			Assert.AreEqual("any", typeof(Dictionary<int, UtilsUnitTests>).ToTypeScriptType().Name);
+		}
+
+		[TestMethod]
+		public void ToTypeScripterType_IDictionary_Int_Object()
+		{
+			Assert.AreEqual("any", typeof(IDictionary<int, UtilsUnitTests>).ToTypeScriptType().Name);
+		}
 	}
 }

--- a/Utils.cs
+++ b/Utils.cs
@@ -67,9 +67,14 @@ namespace TypeScripter {
 
 		private static bool IsGenericEnumerable(Type t)
 		{
-			return t.IsGenericType 
+			if (!t.IsGenericType) {
+				return false;
+			}
+			var typeDef = t.GetGenericTypeDefinition();
+			return typeDef != typeof(Dictionary<,>)
+				&& typeDef != typeof(IDictionary<,>)
 				&& (
-					t.GetGenericTypeDefinition() == typeof(IEnumerable<>) 
+					typeDef == typeof(IEnumerable<>) 
 					|| t.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
 				);
 		}


### PR DESCRIPTION
…to use the ES6 Map<TKey, TValue> object.