### PR TITLE
DataServiceGenerator should ensure that the model constructors get ca…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,3 +258,5 @@ rebuild.cmd
 /.vs/TypeScripter/v14/*.suo
 
 *.ncrunchsolution
+*.ncrunchproject
+/TypeScripter/Properties/launchSettings.json

--- a/TypeScripter.Common/Generators/DataServiceGeneratorUtils.cs
+++ b/TypeScripter.Common/Generators/DataServiceGeneratorUtils.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace TypeScripter.Common.Generators
+{
+    public class DataServiceGeneratorUtils
+    {
+        public static string GetPipeString(Type returnType)
+        {
+            return string.Join(".", GetPipelineSteps(returnType));
+        }
+
+        private static IEnumerable<string> GetPipelineSteps(Type returnType)
+        {
+            string typescriptType = returnType.ToTypeScriptType().Name;
+
+            // Make sure the DTO constructor gets called in the pipeline
+            if (returnType.IsOrContainsModelType())
+            {
+                if (typescriptType.EndsWith("[]"))
+                {
+                    // Arrays need both the map pipeline step as well as the array map to call constructors
+                    var elementType = typescriptType.Substring(0, typescriptType.Length - 2); // Take off the '[]' at the end of the type
+                    yield return $"pipe(map(value => Array.isArray(value) ? value.map(x => new {elementType}(x)) : null))";
+                }
+                else
+                {
+                    // Use the rxjs map to call the model's constructor
+                    yield return $"pipe(map(value => new {typescriptType}(value)))";
+                }
+            }
+            yield return "pipe(catchError(this.handleError))"; // This is always the final step in the pipeline
+        }
+    }
+}

--- a/TypeScripter.Common/Options.cs
+++ b/TypeScripter.Common/Options.cs
@@ -10,7 +10,6 @@ namespace TypeScripter.Common
 		[DataMember] public string[] Files { get; set; }
 		[DataMember] public string[] ControllerBaseClassNames { get; set; }
 		[DataMember] public string ApiRelativePath { get; set; }
-    [DataMember] public string HttpModule { get; set; }
 		[DataMember] public bool? CombineImports { get; set; }
 	  [DataMember] public bool? HandleErrors { get; set; }
 	}

--- a/TypeScripter.Common/TypeScripter.cs
+++ b/TypeScripter.Common/TypeScripter.cs
@@ -109,14 +109,6 @@ namespace TypeScripter.Common
 						{
 							_options.ControllerBaseClassNames = new[] { "ApiController" };
 						}
-						if (string.IsNullOrEmpty(_options.HttpModule))
-						{
-							_options.HttpModule = DataServiceGenerator.Http;
-						}
-						if (_options.HttpModule != DataServiceGenerator.HttpClient && _options.HttpModule != DataServiceGenerator.Http)
-						{
-							throw new Exception(String.Format("HttpModule must be one of {0} or {1}", DataServiceGenerator.Http, DataServiceGenerator.HttpClient));
-						}
 						if (!_options.CombineImports.HasValue)
 						{
 							_options.CombineImports = false;
@@ -154,7 +146,6 @@ namespace TypeScripter.Common
 					ApiRelativePath = apipath != null && apipath.IsString ? (string)apipath.Value : null,
 					Files = files != null && files.IsList && files.AsList.Count == 1 ? ((string)(((ValueObject)files.AsList[0]).Value)).Split(',') : new[] { "*.client.dll" },
 					ControllerBaseClassNames = classnames != null && classnames.IsList && classnames.AsList.Count == 1 ? ((string)(((ValueObject)classnames.AsList[0]).Value)).Split(',') : new[] { "ApiController" },
-					HttpModule = newhttp != null && newhttp.IsTrue ? DataServiceGenerator.HttpClient : DataServiceGenerator.Http,
 					CombineImports = combineImports != null && combineImports.IsTrue ? true : false
 				};
 			}

--- a/TypeScripter.Common/Utils.cs
+++ b/TypeScripter.Common/Utils.cs
@@ -87,7 +87,19 @@ namespace TypeScripter.Common {
 			return isModel;
 		}
 
-		public static Type GetPropertyType(this PropertyInfo pi) {
+        private static readonly HashSet<string> NonModelTypes = 
+            new HashSet<string> {"boolean", "number", "string", "moment.Moment", "any"};
+
+        public static bool IsOrContainsModelType(this Type type)
+	    {
+            // Note: When Enum support is implemented, this code will need to
+            //       be updated to handle enums properly (right now enums act
+            //       like objects)
+	        var typescriptType = ToTypeScriptType(type).Name.Replace("[]", "");
+	        return !NonModelTypes.Contains(typescriptType);
+	    }
+
+	    public static Type GetPropertyType(this PropertyInfo pi) {
 			if(pi.PropertyType.IsGenericType) {
 				return pi.PropertyType.GetGenericArguments()[0];
 			}

--- a/TypeScripter.Tests/DataServiceGeneratorUtilsTests.cs
+++ b/TypeScripter.Tests/DataServiceGeneratorUtilsTests.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TypeScripter.Common.Generators;
+
+namespace TypeScripter.Tests
+{
+    [TestClass]
+    public class DataServiceGeneratorUtilsTests
+    {
+        private class ModelType { }
+
+        [TestMethod]
+        public void GetPipeStringTest_SingleModel()
+        {
+            var result = DataServiceGeneratorUtils.GetPipeString(typeof(ModelType));
+            Assert.AreEqual("pipe(map(value => new ModelType(value))).pipe(catchError(this.handleError))", result);
+        }
+
+        [TestMethod]
+        public void GetPipeStringTest_ArrayOfModel()
+        {
+            var result = DataServiceGeneratorUtils.GetPipeString(typeof(ModelType[]));
+            Assert.AreEqual("pipe(map(value => Array.isArray(value) ? value.map(x => new ModelType(x)) : null)).pipe(catchError(this.handleError))", result);
+        }
+    }
+}

--- a/TypeScripter.Tests/UtilsUnitTests.cs
+++ b/TypeScripter.Tests/UtilsUnitTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TypeScripter.Common;
 
@@ -50,5 +50,85 @@ namespace TypeScripter.Tests
 		{
 			Assert.AreEqual("any", typeof(IDictionary<int, UtilsUnitTests>).ToTypeScriptType().Name);
 		}
-	}
+        
+	    [TestMethod]
+	    public void IsOrContainsModelType_Int()
+	    {
+	        Assert.IsFalse(typeof(int).IsOrContainsModelType());
+	    }
+
+        [TestMethod]
+	    public void IsOrContainsModelType_IntArray()
+	    {
+            Assert.IsFalse(typeof(int[]).IsOrContainsModelType());
+	    }
+
+	    [TestMethod]
+	    public void IsOrContainsModelType_Bool()
+	    {
+	        Assert.IsFalse(typeof(bool).IsOrContainsModelType());
+	    }
+
+	    [TestMethod]
+	    public void IsOrContainsModelType_BoolArray()
+	    {
+	        Assert.IsFalse(typeof(bool[]).IsOrContainsModelType());
+	    }
+
+        [TestMethod]
+	    public void IsOrContainsModelType_String()
+	    {
+	        Assert.IsFalse(typeof(string).IsOrContainsModelType());
+	    }
+
+	    [TestMethod]
+	    public void IsOrContainsModelType_StringArray()
+	    {
+	        Assert.IsFalse(typeof(string[]).IsOrContainsModelType());
+	    }
+
+	    [TestMethod]
+	    public void IsOrContainsModelType_DateTime()
+	    {
+	        Assert.IsFalse(typeof(DateTime).IsOrContainsModelType());
+	    }
+
+	    [TestMethod]
+	    public void IsOrContainsModelType_DateTimeArray()
+	    {
+	        Assert.IsFalse(typeof(DateTime[]).IsOrContainsModelType());
+	    }
+
+        public class TestModel {}
+
+	    [TestMethod]
+	    public void IsOrContainsModelType_SingleModel()
+	    {
+	        Assert.IsTrue(typeof(TestModel).IsOrContainsModelType());
+	    }
+
+	    [TestMethod]
+	    public void IsOrContainsModelType_ArrayOfModel()
+	    {
+	        Assert.IsTrue(typeof(TestModel[]).IsOrContainsModelType());
+	    }
+
+	    [TestMethod]
+	    public void IsOrContainsModelType_TaskOfModel()
+	    {
+	        Assert.IsTrue(typeof(Task<TestModel>).IsOrContainsModelType());
+	    }
+
+	    [TestMethod]
+	    public void IsOrContainsModelType_ListOfModel()
+	    {
+	        Assert.IsTrue(typeof(List<TestModel>).IsOrContainsModelType());
+	    }
+
+	    [TestMethod]
+	    public void IsOrContainsModelType_TaskOfListOfModel()
+	    {
+	        Assert.IsTrue(typeof(Task<List<TestModel>>).IsOrContainsModelType());
+	    }
+    }
 }

--- a/TypeScripter.sln.DotSettings
+++ b/TypeScripter.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Scripter/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
…lled by adding a map stage to the pipeline.

- Both arrays of objects and single objects need to work.
- Since the Angular team has deprecated the old HTTP API we should remove the code that can emit code using that API
- Sort the list of controllers alphabetically