### PR TITLE
Handle null and undefined values in generated DataService GET methods

### DIFF
--- a/TypeScripter.Common/Generators/DataServiceGenerator.cs
+++ b/TypeScripter.Common/Generators/DataServiceGenerator.cs
@@ -241,13 +241,13 @@ namespace TypeScripter.Common.Generators
 		{
 			if (p.ParameterType == typeof(DateTime))
 			{
-				return string.Format("{0}=${{{0}.toISOString()}}", p.Name);
+				return string.Format("{0}=${{{0} == null ? '' : {0}.toISOString()}}", p.Name);
 			}
 			else if (p.ParameterType.ToTypeScriptType().Name.EndsWith("[]"))
 			{
 				return string.Format("${{{0}.map(x => `{0}=${{x}}`).join('&')}}", p.Name);
 			}
-			return string.Format("{0}=${{{0}}}", p.Name);
+			return string.Format("{0}=${{{0} == null ? '' : {0}}}", p.Name);
 		}
 
 		private static string CombineUri(params string[] parts)


### PR DESCRIPTION
If a parameter to a GET call is set to null or undefined, then leave that parameter blank in the generated URL.

Fixes #38 

For example, the original generated code would look like this:

```ts
getStuff: (id: number): Observable<AgencyPart> => this.http.get<Stuff>(`${this.apiRelativePath}/Stuff/GetStuff?id=${id}`).pipe(map(value => new Stuff(value))).pipe(catchError(this.handleError))
```

Resulting in a URL like this if a `null` was passed:

```
/api/Stuff/GetStuff?id=null
```

This update would result in:

```
/api/Stuff/GetStuff?id=
```
